### PR TITLE
Added option to pass custom configuration

### DIFF
--- a/components/A2Base.php
+++ b/components/A2Base.php
@@ -45,24 +45,33 @@ abstract class A2Base extends CComponent
 
 	protected $_client;
 
-	/**
-	 * Returns the aws service builder
-	 * @return Guzzle\Service\Builder\ServiceBuilder
-	 * @throws CException
-	 */
-	public function getAws()
-	{
-		if (null === $this->_aws)
-		{
-			$config = __DIR__ . '/../config/aws-config.php';
-			if (!@file_exists($config))
-				throw new CException(Yii::t('zii', '"aws-config.php" configuration file not found'));
+    /**
+     * Added option to use dynamic configurations instead of a file
+     * @param array $config
+     */
+    public function __construct($config = array())
+    {
+        if (!empty($config))
+            $this->_config = $config;
+    }
 
-			$this->_aws = Aws::factory($config);
-		}
+    /**
+     * Returns the aws service builder
+     * @return Guzzle\Service\Builder\ServiceBuilder
+     * @throws CException
+     */
+    public function getAws()
+    {
+        if (null === $this->_aws) {
+            $config = $this->_config !== null ? $this->_config : __DIR__ . '/../config/aws-config.php';
+            if (is_scalar($config) && !@file_exists($config))
+                throw new CException(Yii::t('zii', '"aws-config.php" configuration file not found'));
 
-		return $this->_aws;
-	}
+            $this->_aws = Aws::factory($config);
+        }
+
+        return $this->_aws;
+    }
 
 	/**
 	 * Magic call to wrapped amazon aws methods. If not command found, then call parent component


### PR DESCRIPTION
From now on, you can pass custom configurations like this:

```
$s3 = new A2S3(array(
    'key'    => '{YOUR-AWS-KEY}',
    'secret' => '{YOUR-AWS-SECRET}',
    'region' => 'us-east-1'     
));

try
{
    return $s3->getClient()->deleteObject(array(
        'Bucket' => $bucket,
        'Key' => $image->filename
    ));
} catch (Aws\S3\Exception\S3Exception $e)
{
    throw $e;
    return false;
}
```

Fixes #23
